### PR TITLE
Remove only_one_promotion_per_product validate form 

### DIFF
--- a/promo/app/models/spree/promotion/rules/product.rb
+++ b/promo/app/models/spree/promotion/rules/product.rb
@@ -6,7 +6,6 @@ module Spree
     module Rules
       class Product < PromotionRule
         has_and_belongs_to_many :products, :class_name => '::Spree::Product', :join_table => 'spree_products_promotion_rules', :foreign_key => 'promotion_rule_id'
-        validate :only_one_promotion_per_product
 
         MATCH_POLICIES = %w(any all)
         preference :match_policy, :string, :default => MATCH_POLICIES.first
@@ -33,13 +32,6 @@ module Spree
           self.product_ids = s.to_s.split(',').map(&:strip)
         end
 
-        private
-
-          def only_one_promotion_per_product
-            if Spree::Promotion::Rules::Product.all.map(&:products).flatten.uniq!
-              errors[:base] << "You can't create two promotions for the same product"
-            end
-          end
       end
     end
   end

--- a/promo/spec/requests/promotion_adjustments_spec.rb
+++ b/promo/spec/requests/promotion_adjustments_spec.rb
@@ -419,6 +419,20 @@ describe "Promotion Adjustments" do
       Spree::Order.last.total.to_f.should == 54.00
     end
 
+    it "should pick the best promotion when two promotions exist for the same product" do
+      create_per_product_promotion("RoR Mug", 5.0)
+      add_to_cart "RoR Mug"
+      Spree::Order.last.total.to_f.should == 35.00
+
+      create_per_product_promotion("RoR Mug", 10.0)
+      Spree::Activator.active.event_name_starts_with('spree.cart.add').size.should == 2
+
+      update_first_item_quantity 0
+      add_to_cart "RoR Mug"
+
+      Spree::Order.last.total.to_f.should == 30.00
+    end
+
     def add_to_cart product_name
       visit spree.root_path
       click_link product_name


### PR DESCRIPTION
promotion/rules/product.rb.

Because we would like to create multi coupons against same product.
But, currently we can not.So, remove its validation.
For remove it, I refered to the following pull request.

[Reference]
https://github.com/spree/spree/pull/1984
