### PR TITLE
Allow the specific authorization or capture of payments on orders.

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -84,3 +84,7 @@
 *   Increase the precision of the amount/price columns in order for support other currencies. See https://github.com/spree/spree/issues/4657
 
     Gonzalo Moreno
+
+*   Add attempt_authorization! and attempt_purchase! to the public interface of payments.
+
+    Richard Wilson

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -88,3 +88,7 @@
 *   Add attempt_authorization! and attempt_purchase! to the public interface of payments.
 
     Richard Wilson
+
+*   Add authorize_payments! and capture_payments! to the public interface of orders.
+
+    Richard Wilson

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -377,6 +377,14 @@ module Spree
       process_payments_with(:process!)
     end
 
+    def authorize_payments!
+      process_payments_with(:attempt_authorization!)
+    end
+
+    def capture_payments!
+      process_payments_with(:attempt_purchase!)
+    end
+
     def billing_firstname
       bill_address.try(:firstname)
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -374,18 +374,7 @@ module Spree
     #   :allow_checkout_on_gateway_error is set to false
     #
     def process_payments!
-      pending_payments.each do |payment|
-        break if payment_total >= total
-
-        payment.process!
-
-        if payment.completed?
-          self.payment_total += payment.amount
-        end
-      end
-    rescue Core::GatewayError => e
-      result = !!Spree::Config[:allow_checkout_on_gateway_error]
-      errors.add(:base, e.message) and return result
+      process_payments_with(:process!)
     end
 
     def billing_firstname
@@ -641,6 +630,25 @@ module Spree
           random_token = SecureRandom.urlsafe_base64(nil, false)
           break random_token unless self.class.exists?(guest_token: random_token)
         end
+      end
+
+      def process_payments_with(method)
+        if pending_payments.empty?
+          raise Core::GatewayError.new Spree.t(:no_pending_payments)
+        else
+          pending_payments.each do |payment|
+            break if payment_total >= total
+
+            payment.public_send(method)
+
+            if payment.completed?
+              self.payment_total += payment.amount
+            end
+          end
+        end
+      rescue Core::GatewayError => e
+        result = !!Spree::Config[:allow_checkout_on_gateway_error]
+        errors.add(:base, e.message) and return result
       end
   end
 end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -2,26 +2,20 @@ module Spree
   class Payment < Spree::Base
     module Processing
       def process!
-        handle_payment_preconditions do
-          if payment_method.auto_capture?
-            purchase!
-          else
-            authorize!
-          end
+        if payment_method.auto_capture?
+          return purchase!
+        else
+          return authorize!
         end
       end
 
       def authorize!
-        started_processing!
-        gateway_action(source, :authorize, :pend)
+        handle_payment_preconditions { process_authorization }
       end
 
       # Captures the entire amount of a payment.
       def purchase!
-        started_processing!
-        result = gateway_action(source, :purchase, :complete)
-        # This won't be called if gateway_action raises a GatewayError
-        capture_events.create!(amount: amount)
+        handle_payment_preconditions { process_purchase }
       end
 
       # Takes the amount in cents to capture.
@@ -139,6 +133,18 @@ module Spree
       end
 
       private
+
+      def process_authorization
+        started_processing!
+        gateway_action(source, :authorize, :pend)
+      end
+
+      def process_purchase
+        started_processing!
+        result = gateway_action(source, :purchase, :complete)
+        # This won't be called if gateway_action raises a GatewayError
+        capture_events.create!(amount: amount)
+      end
 
       def handle_payment_preconditions(&block)
         unless block_given?

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -2,22 +2,11 @@ module Spree
   class Payment < Spree::Base
     module Processing
       def process!
-        if payment_method && payment_method.source_required?
-          if source
-            if !processing?
-              if payment_method.supports?(source)
-                if payment_method.auto_capture?
-                  purchase!
-                else
-                  authorize!
-                end
-              else
-                invalidate!
-                raise Core::GatewayError.new(Spree.t(:payment_method_not_supported))
-              end
-            end
+        handle_payment_preconditions do
+          if payment_method.auto_capture?
+            purchase!
           else
-            raise Core::GatewayError.new(Spree.t(:payment_processing_failed))
+            authorize!
           end
         end
       end
@@ -150,6 +139,27 @@ module Spree
       end
 
       private
+
+      def handle_payment_preconditions(&block)
+        unless block_given?
+          raise ArgumentError("handle_payment_preconditions must be called with a block")
+        end
+
+        if payment_method && payment_method.source_required?
+          if source
+            if !processing?
+              if payment_method.supports?(source)
+                yield
+              else
+                invalidate!
+                raise Core::GatewayError.new(Spree.t(:payment_method_not_supported))
+              end
+            end
+          else
+            raise Core::GatewayError.new(Spree.t(:payment_processing_failed))
+          end
+        end
+      end
 
       def gateway_action(source, action, success_state)
         protect_from_connection_error do

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -119,6 +119,32 @@ module Spree
       end
     end
 
+    context "#authorize_payments!" do
+      let(:payment) { stub_model(Spree::Payment) }
+      before { order.stub :pending_payments => [payment], :total => 10 }
+      subject { order.authorize_payments! }
+
+      it "processes payments with attempt_authorization!" do
+        expect(payment).to receive(:attempt_authorization!)
+        subject
+      end
+
+      it { should be_true }
+    end
+
+    context "#capture_payments!" do
+      let(:payment) { stub_model(Spree::Payment) }
+      before { order.stub :pending_payments => [payment], :total => 10 }
+      subject { order.capture_payments! }
+
+      it "processes payments with attempt_authorization!" do
+        expect(payment).to receive(:attempt_purchase!)
+        subject
+      end
+
+      it { should be_true }
+    end
+
     context "#outstanding_balance" do
       it "should return positive amount when payment_total is less than total" do
         order.payment_total = 20.20

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -104,22 +104,17 @@ describe Spree::Payment do
   end
 
   context "processing" do
-    before do
-      payment.stub(:update_order)
-      payment.stub(:create_payment_profile)
-    end
-
     describe "#process!" do
       it "should purchase if with auto_capture" do
         payment.payment_method.should_receive(:auto_capture?).and_return(true)
-        payment.should_receive(:purchase!)
         payment.process!
+        expect(payment).to be_completed
       end
 
       it "should authorize without auto_capture" do
         payment.payment_method.should_receive(:auto_capture?).and_return(false)
-        payment.should_receive(:authorize!)
         payment.process!
+        expect(payment).to be_pending
       end
 
       it "should make the state 'processing'" do
@@ -132,7 +127,6 @@ describe Spree::Payment do
         expect { payment.process!}.to raise_error(Spree::Core::GatewayError)
         payment.state.should eq('invalid')
       end
-
     end
 
     describe "#authorize!" do
@@ -473,8 +467,6 @@ describe Spree::Payment do
     it "should return nil without trying to process the source" do
       payment.state = 'processing'
 
-      payment.should_not_receive(:authorize!)
-      payment.should_not_receive(:purchase!)
       payment.process!.should be_nil
     end
   end
@@ -819,13 +811,13 @@ describe Spree::Payment do
 
       context "amount contains a $ sign" do
         let(:amount) { '2,99 $' }
-        
+
         its(:amount) { should eql(BigDecimal('2.99')) }
       end
 
       context "amount is a number" do
         let(:amount) { 2.99 }
-        
+
         its(:amount) { should eql(BigDecimal('2.99')) }
       end
 


### PR DESCRIPTION
There are times when, regardless of store configuration or payment_method preferences we need to explicitly capture or purchase payments. An example of this is a review step between the complete and confirm states for spree order.
