### PR TITLE
Fix incompatibility with ujs

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -107,27 +107,19 @@ module Spree
       end
 
       def button_link_to(text, url, html_options = {})
-        if (html_options[:method] &&
-            html_options[:method].to_s.downcase != 'get' &&
-            !html_options[:remote])
-          form_tag(url, :method => html_options.delete(:method)) do
-            button(text, html_options.delete(:icon), nil, html_options)
-          end
-        else
-          if html_options['data-update'].nil? && html_options[:remote]
-            object_name, action = url.split('/')[-2..-1]
-            html_options['data-update'] = [action, object_name.singularize].join('_')
-          end
-
-          html_options.delete('data-update') unless html_options['data-update']
-
-          html_options[:class] = 'button'
-
-          if html_options[:icon]
-            html_options[:class] += " fa fa-#{html_options[:icon]}"
-          end
-          link_to(text_for_button_link(text, html_options), url, html_options)
+        if html_options['data-update'].nil? && html_options[:remote]
+          object_name, action = url.split('/')[-2..-1]
+          html_options['data-update'] = [action, object_name.singularize].join('_')
         end
+
+        html_options.delete('data-update') unless html_options['data-update']
+
+        html_options[:class] = 'button'
+
+        if html_options[:icon]
+          html_options[:class] += " fa fa-#{html_options[:icon]}"
+        end
+        link_to(text_for_button_link(text, html_options), url, html_options)
       end
 
       def text_for_button_link(text, html_options)


### PR DESCRIPTION
Stop rendering button links inside of forms, instead render them as
links and let ujs handle them normally. This fixes an issue where links
would launch two confirm boxes but not actually hit the correct url when
a confirm was specified due to it hitting two different jquery_ujs event
handlers. The buttons will now only hit one of the handlers.
