### PR TITLE
Cherry pick and modify shipment transfer endpoints from later versions of Spree

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -71,15 +71,15 @@ module Spree
       end
 
       def transfer_to_location
-        success, message = @original_shipment.transfer_to_location(@variant, @quantity, @stock_location)
-        status = success ? 201 : 422
-        render json: {success: success, message: message}, status: status
+        @stock_location = Spree::StockLocation.find(params[:stock_location_id])
+        @original_shipment.transfer_to_location(@variant, @quantity, @stock_location)
+        render json: {success: true, message: Spree.t(:shipment_transfer_success)}, status: 201
       end
 
       def transfer_to_shipment
-        success, message = @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment)
-        status = success ? 201 : 422
-        render json: {success: success, message: message}, status: status
+        @target_shipment  = Spree::Shipment.find_by!(number: params[:target_shipment_number])
+        @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment)
+        render json: {success: true, message: Spree.t(:shipment_transfer_success)}, status: 201
       end
 
       private
@@ -94,10 +94,8 @@ module Spree
 
       def load_transfer_params
         @original_shipment         = Spree::Shipment.where(number: params[:original_shipment_number]).first
-        @target_shipment           = params[:target_shipment_number] ? Spree::Shipment.where(number: params[:target_shipment_number]).first : nil
         @variant                   = Spree::Variant.find(params[:variant_id])
         @quantity                  = params[:quantity].to_i
-        @stock_location            = params[:stock_location_id] ? Spree::StockLocation.find(params[:stock_location_id]) : nil
         authorize! :read, @original_shipment
         authorize! :create, Shipment
       end

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -4,6 +4,7 @@ module Spree
 
       before_filter :find_order
       before_filter :find_and_update_shipment, only: [:ship, :ready, :add, :remove]
+      before_filter :load_transfer_params, only: [:transfer_to_location, :transfer_to_shipment]
 
       def create
         # TODO Can remove conditional here once deprecated #find_order is removed.
@@ -69,6 +70,18 @@ module Spree
         respond_with(@shipment, default_template: :show)
       end
 
+      def transfer_to_location
+        success, message = @original_shipment.transfer_to_location(@variant, @quantity, @stock_location)
+        status = success ? 201 : 422
+        render json: {success: success, message: message}, status: status
+      end
+
+      def transfer_to_shipment
+        success, message = @original_shipment.transfer_to_shipment(@variant, @quantity, @target_shipment)
+        status = success ? 201 : 422
+        render json: {success: success, message: message}, status: status
+      end
+
       private
 
       def find_order
@@ -77,6 +90,16 @@ module Spree
           @order = Spree::Order.find_by!(number: params[:order_id])
           authorize! :read, @order
         end
+      end
+
+      def load_transfer_params
+        @original_shipment         = Spree::Shipment.where(number: params[:original_shipment_number]).first
+        @target_shipment           = params[:target_shipment_number] ? Spree::Shipment.where(number: params[:target_shipment_number]).first : nil
+        @variant                   = Spree::Variant.find(params[:variant_id])
+        @quantity                  = params[:quantity].to_i
+        @stock_location            = params[:stock_location_id] ? Spree::StockLocation.find(params[:stock_location_id]) : nil
+        authorize! :read, @original_shipment
+        authorize! :create, Shipment
       end
 
       def find_and_update_shipment

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -21,8 +21,8 @@ module Spree
       end
 
       def index
-        @variants = scope.includes(:option_values).ransack(params[:q]).result.
-          page(params[:page]).per(params[:per_page])
+        @variants = scope.includes({ option_values: :option_type }, :product, :default_price, :images, { stock_items: :stock_location })
+          .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         respond_with(@variants)
       end
 

--- a/api/app/views/spree/api/variants/big.v1.rabl
+++ b/api/app/views/spree/api/variants/big.v1.rabl
@@ -5,6 +5,11 @@ cache [I18n.locale, 'big_variant', root_object]
 
 extends "spree/api/variants/small"
 
+node :total_on_hand do
+  root_object.total_on_hand
+end
+
+
 child(:stock_items => :stock_items) do
   attributes :id, :count_on_hand, :stock_location_id, :backorderable
   attribute :available? => :available

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -77,7 +77,12 @@ Spree::Core::Engine.add_routes do
     resources :countries, :only => [:index, :show] do
       resources :states, :only => [:index, :show]
     end
-    resources :shipments, :only => [:create, :update] do
+    resources :shipments, only: [:create, :update] do
+      collection do
+        post 'transfer_to_location'
+        post 'transfer_to_shipment'
+      end
+
       member do
         put :ready
         put :ship

--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -274,4 +274,14 @@ $(document).ready(function(){
   $('a.dismiss').click(function() {
     $(this).parent().fadeOut();
   });
+
+  window.Spree.advanceOrder = function() {
+      $.ajax({
+          type: "PUT",
+          async: false,
+          url: Spree.url(Spree.routes.checkouts_api + "/" + order_number + "/advance")
+      }).done(function() {
+          window.location.reload();
+      });
+  }
 });

--- a/backend/app/assets/javascripts/spree/backend/line_items.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/line_items.js.coffee
@@ -48,7 +48,7 @@ adjustLineItem = (line_item_id, quantity) ->
         quantity: quantity
       token: Spree.api_key
   ).done (msg) ->
-    advanceOrder()
+    window.Spree.advanceOrder()
 
 deleteLineItem = (line_item_id) ->
   url = lineItemURL(line_item_id)
@@ -61,4 +61,4 @@ deleteLineItem = (line_item_id) ->
     $('#line-item-' + line_item_id).remove()
     if $('.line-items tr.line-item').length == 0
       $('.line-items').remove()
-    advanceOrder()
+    window.Spree.advanceOrder()

--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -233,8 +233,13 @@ startItemSplit = function(event){
 
 completeItemSplit = function(event) {
   event.preventDefault();
+
+  if($('#item_stock_location').val() === ""){
+      alert('Please select the split destination.');
+      return false;
+  }
+
   var link = $(this);
-  var order_number = link.closest('tbody').data('order-number');
   var stock_item_row = link.closest('tr');
   var variant_id = stock_item_row.data('variant-id');
   var quantity = stock_item_row.find('#item_quantity').val();
@@ -247,44 +252,42 @@ completeItemSplit = function(event) {
   var new_shipment = selected_shipment.data('new-shipment');
 
   if (stock_location_id != 'new_shipment') {
-    // first remove item(s) from original shipment
-    $.ajax({
-      type: "PUT",
-      async: false,
-      url: Spree.url(Spree.routes.shipments_api + "/" + original_shipment_number + "/remove.json"),
-      data: { variant_id: variant_id, quantity: quantity }
-    });
-
     if (new_shipment != undefined) {
+      // TRANSFER TO A NEW LOCATION
       $.ajax({
         type: "POST",
         async: false,
-        url: Spree.url(Spree.routes.shipments_api + "?shipment[order_id]=" + order_number),
-        data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id, token: Spree.api_key }
+        url: Spree.url(Spree.routes.shipments_api + "/transfer_to_location"),
+        data: {
+            original_shipment_number: original_shipment_number,
+            variant_id: variant_id,
+            quantity: quantity,
+            stock_location_id: stock_location_id
+        }
+      }).error(function(msg) {
+          alert(msg.responseJSON['message']);
       }).done(function(msg) {
-        advanceOrder();
+        window.Spree.advanceOrder();
       });
     } else {
+      // TRANSFER TO AN EXISTING SHIPMENT
       $.ajax({
-        type: "PUT",
+        type: "POST",
         async: false,
-        url: Spree.url(Spree.routes.shipments_api + "/" + target_shipment_number + "/add.json"),
-        data: { variant_id: variant_id, quantity: quantity, token: Spree.api_key }
+        url: Spree.url(Spree.routes.shipments_api + "/transfer_to_shipment"),
+        data: {
+          original_shipment_number: original_shipment_number,
+          target_shipment_number: target_shipment_number,
+          variant_id: variant_id,
+          quantity: quantity
+        }
+      }).error(function(msg) {
+        alert(msg.responseJSON['message']);
       }).done(function(msg) {
-        advanceOrder();
+        window.Spree.advanceOrder();
       });
     }
   }
-}
-
-advanceOrder = function() {
-  $.ajax({
-    type: "PUT",
-    async: false,
-    url: Spree.url(Spree.routes.checkouts_api + "/" + order_number + "/advance")
-  }).done(function() {
-    window.location.reload();
-  });
 }
 
 cancelItemSplit = function(event) {

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -3,8 +3,8 @@
     <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @line_item } %>
   <% end %>
 
-  <% if Spree::Order.checkout_step_names.include?(:delivery) && !%w(cart address).include?(@order.state) %>
-    <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments, :locals => { :order => order } %>
+  <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+    <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments.order(:created_at), :locals => { :order => order } %>
   <% else %>
     <%= render :partial => "spree/admin/orders/line_items", :locals => { :order => order } %>
   <% end %>

--- a/backend/app/views/spree/admin/variants/_split.js.erb
+++ b/backend/app/views/spree/admin/variants/_split.js.erb
@@ -13,7 +13,7 @@
       </optgroup>
       <optgroup label="<%=Spree.t('new_shipment_at_location')%>">
         {{#each variant.stock_items}}
-          <option data-new-shipment='true' value='{{this.stock_location_id}}'>{{this.stock_location_name}}</option>
+          <option data-new-shipment='true' value='{{this.stock_location_id}}'>{{this.stock_location_name}}&nbsp({{this.count_on_hand}} on hand)</option>
         {{/each}}
       </optgroup>
       </select>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -7,7 +7,7 @@ describe "Order Details", js: true do
   let!(:tote) { create(:product, :name => "Tote", :price => 15.00) }
   let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100") }
   let(:state) { create(:state) }
-  let(:shipment) { create(:shipment, :order => order, :stock_location => stock_location) }
+  #let(:shipment) { create(:shipment, :order => order, :stock_location => stock_location) }
   let!(:shipping_method) { create(:shipping_method, :name => "Default") }
 
   before do
@@ -18,9 +18,12 @@ describe "Order Details", js: true do
   context 'as Admin' do
     stub_authorization!
 
-    before { visit spree.edit_admin_order_path(order) }
+    context "cart edit page" do
+      before do
+        product.master.stock_items.first.update_column(:count_on_hand, 100)
+        visit spree.edit_admin_order_path(order)
+      end
 
-    context "edit order page" do
       it "should allow me to edit order details" do
         page.should have_content("spree t-shirt")
         page.should have_content("$40.00")
@@ -37,6 +40,7 @@ describe "Order Details", js: true do
       end
 
       it "can add an item to a shipment" do
+        select2_search "spree t-shirt", :from => Spree.t(:name_or_sku)
         select2_search "Tote", :from => Spree.t(:name_or_sku)
         within("table.stock-levels") do
           fill_in "stock_item_quantity", :with => 2
@@ -76,6 +80,8 @@ describe "Order Details", js: true do
       end
 
       it "can add tracking information" do
+        visit spree.edit_admin_order_path(order)
+
         within(".show-tracking") do
           click_icon :edit
         end
@@ -107,125 +113,308 @@ describe "Order Details", js: true do
       end
 
       context "variant out of stock and not backorderable" do
-        before { product.master.stock_items.first.update_column(:backorderable, false) }
+        before do
+          product.master.stock_items.first.update_column(:backorderable, false)
+          product.master.stock_items.first.update_column(:count_on_hand, 0)
+        end
 
         it "displays out of stock instead of add button" do
           select2_search product.name, :from => Spree.t(:name_or_sku)
+
           within("table.stock-levels") do
             page.should have_content(Spree.t(:out_of_stock))
           end
         end
       end
+    end
 
-      context "when two stock locations exist" do
-        let!(:london) { create(:stock_location, name: "London") }
-        before(:each) { london.stock_items.each { |si| si.adjust_count_on_hand(10) } }
 
-        it "creates a new shipment when adding a variant from the new location" do
-          select2_search "Tote", :from => Spree.t(:name_or_sku)
-          within("table.stock-levels tr:nth-child(2)") do
-            fill_in "stock_item_quantity", :with => 2
-            click_icon :plus
-          end
-          wait_for_ajax
-          page.should have_css("#shipment_#{order.shipments.last.id}")
-          order.shipments.last.stock_location.should == london
-          within "#shipment_#{order.shipments.last.id}" do
-            page.should have_content("LONDON")
-          end
-        end
+    context 'Shipment edit page' do
+      let!(:stock_location2) { create(:stock_location_with_items, name: 'Clarksville') }
 
-        context "when two shipments exist" do
-          before(:each) do
-            select2_search "Tote", :from => Spree.t(:name_or_sku)
-            within("table.stock-levels tr:nth-child(2)") do
-              fill_in "stock_item_quantity", :with => 2
-              click_icon :plus
-              wait_for_ajax
-            end
-          end
+      before do
+        product.master.stock_items.first.update_column(:backorderable, true)
+        product.master.stock_items.first.update_column(:count_on_hand, 100)
+        product.master.stock_items.last.update_column(:count_on_hand, 100)
+      end
 
-          it "updates quantity of the second shipment's items" do
-            within("table.stock-contents", :text => tote.name) do
-              click_icon :edit
-              fill_in "quantity", with: 4
-              click_icon :check
-            end
+      context 'splitting to location' do
+        before { visit spree.edit_admin_order_path(order) }
+        # can not properly implement until poltergeist supports checking alert text
+        # see https://github.com/teampoltergeist/poltergeist/pull/516
+        it 'should warn you if you have not selected a location or shipment'
 
-            # poltergeist and selenium disagree on the existance of this space
-            page.should have_content(/TOTAL: ?\$100\.00/)
-          end
+        context 'there is enough stock at the other location' do
+          it 'should allow me to make a split' do
+            order.shipments.count.should == 1
+            order.shipments.first.inventory_units_for(product.master).count.should == 2
 
-          it "can add tracking information for the second shipment" do
-            within("#shipment_#{order.shipments.last.id}") do
-              within("tr.show-tracking") do
-                click_icon :edit
-              end
-
-              fill_in "tracking", :with => "TRACKING_NUMBER"
-              click_icon :check
-            end
-
-            page.should_not have_css("input[name=tracking]")
-            page.should have_content("Tracking: TRACKING_NUMBER")
-          end
-
-          it "can change the second shipment's shipping method" do
-            click_link "Customer Details"
-
-            check "order_use_billing"
-            fill_in "order_bill_address_attributes_firstname", :with => "Joe"
-            fill_in "order_bill_address_attributes_lastname", :with => "User"
-            fill_in "order_bill_address_attributes_address1", :with => "7735 Old Georgetown Road"
-            fill_in "order_bill_address_attributes_address2", :with => "Suite 510"
-            fill_in "order_bill_address_attributes_city", :with => "Bethesda"
-            fill_in "order_bill_address_attributes_zipcode", :with => "20814"
-            fill_in "order_bill_address_attributes_phone", :with => "301-444-5002"
-            select2 "Alabama", :from => "State"
-            select2 "United States of America", :from => "Country"
-            click_icon :refresh
-
-            click_link "Order Details"
-
-            within("#shipment_#{order.shipments.last.id}") do
-              within("tr.show-method") do
-                click_icon :edit
-              end
-              select2 "Default", :from => "Shipping Method"
-            end
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             click_icon :check
 
-            page.should_not have_css('#selected_shipping_rate_id')
-            page.should have_content("Default")
+            wait_for_ajax
+
+            order.shipments.count.should == 2
+            order.shipments.last.backordered?.should == false
+            order.shipments.first.inventory_units_for(product.master).count.should == 1
+            order.shipments.last.inventory_units_for(product.master).count.should == 1
+          end
+
+          it 'should allow me to make a transfer via splitting off all stock' do
+            order.shipments.first.stock_location.id.should == stock_location.id
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 2
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 1
+            order.shipments.last.backordered?.should == false
+            order.shipments.first.inventory_units_for(product.master).count.should == 2
+            order.shipments.first.stock_location.id.should == stock_location2.id
+          end
+
+          it 'should allow me to split more than I have if available there' do
+            order.shipments.first.stock_location.id.should == stock_location.id
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 5
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 1
+            order.shipments.last.backordered?.should == false
+            order.shipments.first.inventory_units_for(product.master).count.should == 5
+            order.shipments.first.stock_location.id.should == stock_location2.id
+          end
+
+          it 'should not split anything if the input quantity is garbage' do
+            order.shipments.first.stock_location.id.should == stock_location.id
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 'ff'
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 1
+            order.shipments.first.inventory_units_for(product.master).count.should == 2
+            order.shipments.first.stock_location.id.should == stock_location.id
+          end
+
+          it 'should not allow less than or equal to zero qty' do
+            order.shipments.first.stock_location.id.should == stock_location.id
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 0
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 1
+            order.shipments.first.inventory_units_for(product.master).count.should == 2
+            order.shipments.first.stock_location.id.should == stock_location.id
+
+
+            fill_in 'item_quantity', with: -1
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 1
+            order.shipments.first.inventory_units_for(product.master).count.should == 2
+            order.shipments.first.stock_location.id.should == stock_location.id
+          end
+
+          context 'A shipment has shipped' do
+
+            it 'should not show or let me back to the cart page, nor show the shipment edit buttons' do
+              order = create(:order, :state => 'payment', :number => "R100")
+              order.shipments.create!(stock_location_id: stock_location.id, state: 'shipped')
+
+              visit spree.edit_admin_order_path(order)
+
+              page.current_path.should == spree.edit_admin_order_path(order)
+              page.should_not have_text 'Cart'
+              page.should_not have_selector('.fa-arrows-h')
+              page.should_not have_selector('.fa-trash')
+            end
+
+          end
+        end
+
+        context 'there is not enough stock at the other location' do
+          context 'and it cannot backorder' do
+            it 'should not allow me to split stock' do
+              product.master.stock_items.last.update_column(:backorderable, false)
+              product.master.stock_items.last.update_column(:count_on_hand, 0)
+
+              within_row(1) { click_icon 'arrows-h' }
+              targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
+              fill_in 'item_quantity', with: 2
+              click_icon :check
+
+              wait_for_ajax
+
+              order.shipments.count.should == 1
+              order.shipments.first.inventory_units_for(product.master).count.should == 2
+              order.shipments.first.stock_location.id.should == stock_location.id
+            end
+
+          end
+
+          context 'but it can backorder' do
+            it 'should allow me to split and backorder the stock' do
+              product.master.stock_items.last.update_column(:count_on_hand, 0)
+              product.master.stock_items.last.update_column(:backorderable, true)
+
+              within_row(1) { click_icon 'arrows-h' }
+              targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
+              fill_in 'item_quantity', with: 2
+              click_icon :check
+
+              wait_for_ajax
+
+              order.shipments.count.should == 1
+              order.shipments.first.inventory_units_for(product.master).count.should == 2
+              order.shipments.first.stock_location.id.should == stock_location2.id
+            end
+          end
+        end
+
+        context 'multiple items in cart' do
+          it 'should have no problem splitting if multiple items are in the from shipment' do
+            order.contents.add(create(:variant), 2)
+            order.shipments.count.should == 1
+            order.shipments.first.manifest.count.should == 2
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 2
+            order.shipments.last.backordered?.should == false
+            order.shipments.first.inventory_units_for(product.master).count.should == 1
+            order.shipments.last.inventory_units_for(product.master).count.should == 1
           end
         end
       end
 
-      context "with special_instructions present" do
-        let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100", :special_instructions => "Very special instructions here") }
-        it "will show the special_instructions" do
-          visit spree.edit_admin_order_path(order)
-          expect(page).to have_content("Very special instructions here")
-        end
-      end
-
-      context "variant doesn't track inventory" do
+      context 'splitting to shipment' do
         before do
-          tote.master.update_column :track_inventory, false
-          # make sure there's no stock level for any item
-          tote.master.stock_items.update_all count_on_hand: 0, backorderable: false
+          @shipment2 = order.shipments.create(stock_location_id: stock_location2.id)
+          visit spree.edit_admin_order_path(order)
         end
 
-        it "adds variant to order just fine"  do
-          select2_search tote.name, :from => Spree.t(:name_or_sku)
+        it 'should delete the old shipment if enough are split off' do
+          order.shipments.count.should == 2
 
-          within("table.stock-levels") do
-            fill_in "stock_item_quantity", :with => 1
-            click_icon :plus
+          within_row(1) { click_icon 'arrows-h' }
+          targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+          fill_in 'item_quantity', with: 2
+          click_icon :check
+
+          wait_for_ajax
+
+          order.shipments.count.should == 1
+          order.shipments.last.inventory_units_for(product.master).count.should == 2
+        end
+
+        context 'receiving shipment can not backorder' do
+          before { product.master.stock_items.last.update_column(:backorderable, false) }
+
+          it 'should not allow a split if the receiving shipment qty plus the incoming is greater than the count_on_hand' do
+            order.shipments.count.should == 2
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 1
+            click_icon :check
+
+            wait_for_ajax
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 200
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 2
+            order.shipments.first.inventory_units_for(product.master).count.should == 1
+            order.shipments.last.inventory_units_for(product.master).count.should == 1
           end
 
-          within(".stock-contents") do
-            page.should have_content(tote.name)
+          it 'should not allow a shipment to split stock to itself' do
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 order.shipments.first.number, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 1
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 2
+            order.shipments.first.inventory_units_for(product.master).count.should == 2
+          end
+
+          context "when splitting to a shipment that already has line items" do
+            let(:variant2) { create :variant }
+            before do
+              order.contents.add(variant2, 2, order.currency, @shipment2)
+            end
+
+            it 'works as expected' do
+              within_row(1) { click_icon 'arrows-h' }
+              targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+              fill_in 'item_quantity', with: 1
+              click_icon :check
+
+              wait_for_ajax
+
+              order.shipments.count.should == 2
+              order.shipments.first.inventory_units_for(product.master).count.should == 1
+              order.shipments.last.inventory_units_for(product.master).count.should == 1
+              order.shipments.first.inventory_units_for(variant2).count.should == 0
+              order.shipments.last.inventory_units_for(variant2).count.should == 2
+            end
+          end
+        end
+
+        context 'receiving shipment can backorder' do
+          it 'should add more to the backorder' do
+            product.master.stock_items.last.update_column(:backorderable, true)
+            product.master.stock_items.last.update_column(:count_on_hand, 0)
+            @shipment2.reload.backordered?.should == false
+
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 1
+            click_icon :check
+
+            wait_for_ajax
+
+            @shipment2.reload.backordered?.should == true
+
+            within_row(1) { click_icon 'arrows-h' }
+            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+            fill_in 'item_quantity', with: 1
+            click_icon :check
+
+            wait_for_ajax
+
+            order.shipments.count.should == 1
+            order.shipments.last.inventory_units_for(product.master).count.should == 2
+            @shipment2.reload.backordered?.should == true
           end
         end
       end
@@ -242,6 +431,7 @@ describe "Order Details", js: true do
     end
     it "should not display forbidden links" do
       visit spree.edit_admin_order_path(order)
+
       page.should_not have_button('cancel')
       page.should_not have_button('Resend')
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -71,7 +71,7 @@ module Spree
           end
         end
 
-        line_item.save
+        line_item.save!
         line_item
       end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -318,52 +318,40 @@ module Spree
     end
 
     def transfer_to_location(variant, quantity, stock_location)
-      success = true
-      message = Spree.t(:shipment_transfer_success)
-      if (quantity <= 0 || !enough_stock_at_destination_location(variant, quantity, stock_location))
-        return [false, Spree.t(:shipment_transfer_error)]
+      if quantity <= 0
+        raise ArgumentError
       end
 
-      begin
-        transaction do
-          self.order.contents.remove(variant, quantity, self)
-          new_shipment = self.order.shipments.create!(stock_location: stock_location)
-          self.order.contents.add(variant, quantity, nil, new_shipment)
-        end
-      rescue Exception => e
-        Rails.logger.error e.message
-        message  = Spree.t(:shipment_transfer_error)
-        success = false
-      end
+      transaction do
+        new_shipment = order.shipments.create!(stock_location: stock_location)
 
-      [success, message]
+        order.contents.remove(variant, quantity, self)
+        order.contents.add(variant, quantity, order.currency, new_shipment)
+
+        refresh_rates
+        save!
+        new_shipment.refresh_rates
+        new_shipment.save!
+      end
     end
 
     def transfer_to_shipment(variant, quantity, shipment_to_transfer_to)
-      success = true
-      message = Spree.t(:shipment_transfer_success)
-
       quantity_already_shipment_to_transfer_to = shipment_to_transfer_to.manifest.find{|mi| mi.line_item.variant == variant}.try(:quantity) || 0
       final_quantity = quantity + quantity_already_shipment_to_transfer_to
 
-      if (quantity <= 0 || self.id == shipment_to_transfer_to.id || !enough_stock_at_destination_location(variant, final_quantity, shipment_to_transfer_to.stock_location))
-        return [false, Spree.t(:shipment_transfer_error)]
+      if (quantity <= 0 || self == shipment_to_transfer_to)
+        raise ArgumentError
       end
 
-      begin
-        transaction do
-          self.order.contents.remove(variant, quantity, self)
-          shipment_to_transfer_to.order.contents.add(variant, quantity, nil, shipment_to_transfer_to)
-          shipment_to_transfer_to.refresh_rates
-          shipment_to_transfer_to.save!
-        end
-      rescue Exception => e
-        Rails.logger.error e.message
-        message  = Spree.t(:shipment_transfer_error)
-        success = false
-      end
+      transaction do
+        order.contents.remove(variant, quantity, self)
+        order.contents.add(variant, quantity, order.currency, shipment_to_transfer_to)
 
-      [success, message]
+        refresh_rates
+        save!
+        shipment_to_transfer_to.refresh_rates
+        shipment_to_transfer_to.save!
+      end
     end
 
     private

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -330,7 +330,9 @@ module Spree
 
         refresh_rates
         save!
-        new_shipment.refresh_rates
+
+        # Order contents makes the shipping rates stale. This is required.
+        new_shipment.reload.refresh_rates
         new_shipment.save!
       end
     end
@@ -349,7 +351,9 @@ module Spree
 
         refresh_rates
         save!
-        shipment_to_transfer_to.refresh_rates
+
+        # Order contents makes the shipping rates stale. This is required.
+        shipment_to_transfer_to.reload.refresh_rates
         shipment_to_transfer_to.save!
       end
     end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -317,10 +317,63 @@ module Spree
       end
     end
 
+    def transfer_to_location(variant, quantity, stock_location)
+      success = true
+      message = Spree.t(:shipment_transfer_success)
+      if (quantity <= 0 || !enough_stock_at_destination_location(variant, quantity, stock_location))
+        return [false, Spree.t(:shipment_transfer_error)]
+      end
+
+      begin
+        transaction do
+          self.order.contents.remove(variant, quantity, self)
+          new_shipment = self.order.shipments.create!(stock_location: stock_location)
+          self.order.contents.add(variant, quantity, nil, new_shipment)
+        end
+      rescue Exception => e
+        Rails.logger.error e.message
+        message  = Spree.t(:shipment_transfer_error)
+        success = false
+      end
+
+      [success, message]
+    end
+
+    def transfer_to_shipment(variant, quantity, shipment_to_transfer_to)
+      success = true
+      message = Spree.t(:shipment_transfer_success)
+
+      quantity_already_shipment_to_transfer_to = shipment_to_transfer_to.manifest.find{|mi| mi.line_item.variant == variant}.try(:quantity) || 0
+      final_quantity = quantity + quantity_already_shipment_to_transfer_to
+
+      if (quantity <= 0 || self.id == shipment_to_transfer_to.id || !enough_stock_at_destination_location(variant, final_quantity, shipment_to_transfer_to.stock_location))
+        return [false, Spree.t(:shipment_transfer_error)]
+      end
+
+      begin
+        transaction do
+          self.order.contents.remove(variant, quantity, self)
+          shipment_to_transfer_to.order.contents.add(variant, quantity, nil, shipment_to_transfer_to)
+          shipment_to_transfer_to.refresh_rates
+          shipment_to_transfer_to.save!
+        end
+      rescue Exception => e
+        Rails.logger.error e.message
+        message  = Spree.t(:shipment_transfer_error)
+        success = false
+      end
+
+      [success, message]
+    end
+
     private
 
       def manifest_unstock(item)
         stock_location.unstock item.variant, item.quantity, self
+      end
+
+      def can_get_rates?
+        order.ship_address && order.ship_address.valid?
       end
 
       def manifest_restock(item)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1041,6 +1041,8 @@ en:
       pending: pending
       ready: ready
       shipped: shipped
+    shipment_transfer_success: 'Variants successfully transferred'
+    shipment_transfer_error: 'There was an error transferring variants'
     shipments: Shipments
     shipped: Shipped
     shipping: Shipping


### PR DESCRIPTION
Brings in a modified version of:
https://github.com/spree/spree/commit/b252e9adcd02b5b0f0f89cdcfae583e72ae12fb7

Without the cart interface.

As well as https://github.com/freerunningtech/spree/commit/2076c2c62855cc90d4d761090ccd7968ef423eb6
