### PR TITLE
Sanitize user emails in select2

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
         $('#guest_checkout_false').prop("checked", true);
         $('#guest_checkout_false').prop("disabled", false);
 
-        return customer.email;
+        return Select2.util.escapeMarkup(customer.email);
       }
     })
   }

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -1,6 +1,10 @@
 $.fn.userAutocomplete = function () {
   'use strict';
 
+  function formatUser(user) {
+    return Select2.util.escapeMarkup(user.email);
+  }
+
   this.select2({
     minimumInputLength: 1,
     multiple: true,
@@ -26,12 +30,8 @@ $.fn.userAutocomplete = function () {
         };
       }
     },
-    formatResult: function (user) {
-      return user.email;
-    },
-    formatSelection: function (user) {
-      return user.email;
-    }
+    formatResult: formatUser,
+    formatSelection: formatUser
   });
 };
 


### PR DESCRIPTION
select2 will render HTML returned from formatResult and formatSelection.
Users are intended to use the escapeMarkup method when writing these
methods.

An attacker could inject HTML into the admin be signing up with a
specially crafted email address.
